### PR TITLE
Rename ancestry to parentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,12 @@ Performing a search will execute these three steps:
 
 #### Defining an in-app query class
 
+_Attention! From version 1.0.3 we have renamed `ancestry` column to `parentage` for possibility of using Ancestry gem.
+Please, add setting `parentage_column` in your app, if you want to continue use `ancestry` column instead._
+```
+Fias.config.add_setting(:parentage_column, :ancestry)
+```
+
 We'll use the `sequel` gem in this example.
 
 ```ruby
@@ -250,7 +256,7 @@ class Query
     op = Sequel.pg_array_op(:tokens)
 
     DB[:address_objects]
-      .select(:id, :name, :abbr, :parent_id, :ancestry, :forms, :tokens)
+      .select(:id, :name, :abbr, :parent_id, :parentage, :forms, :tokens)
       .where(op.overlaps(tokens))
       .to_a
   end
@@ -260,7 +266,7 @@ end
 `#find` accepts splitted object name (a result of `Fias::Name::Split.split`). It searches all address objects with their tokens matching a given set of tokens. It returns an array of hashes with keys you can see above.
 
 * `:abbr` - FIAS shortname value.
-* `:ancestry` - array of ancestor IDs.
+* `:parentage` - array of ancestor IDs.
 * `:forms` - object name forms (`Fias::Name::Synonyms.forms`)
 * `:tokens` - object name tokens (`Fias::Name::Synonyms.tokens`)
 
@@ -286,7 +292,7 @@ Allowed params are: `%i(region district city subcity street)`
 ```ruby
 query.perform
 #
-# [[13213, {:id=>72344, :name=>"Шолом-Алейхема", :abbr=>"ул", :parent_id=>184027, :ancestry=>[184027, 12550], :forms=>["шолом-
+# [[13213, {:id=>72344, :name=>"Шолом-Алейхема", :abbr=>"ул", :parent_id=>184027, :parentage=>[184027, 12550], :forms=>["шолом-
 # алейхема"], :tokens=>["шолом-алейхема"], :key=>:street}]]
 ```
 

--- a/examples/add_ancestry.rb
+++ b/examples/add_ancestry.rb
@@ -1,0 +1,48 @@
+# Can be run in cloned repo
+# DATABASE_URL=postgres://localhost/fias bundle exec ruby add_ancestry.rb
+#
+# Start this task only when you had finished generate index with parentage column.
+
+require 'ruby-progressbar'
+require 'sequel'
+require 'active_support/core_ext/object/blank'
+require 'fias'
+
+def create_bar(count)
+  ProgressBar.create(total: count, format: '%a |%B| [%E] (%c/%C) %p%%')
+end
+
+DB = Sequel.connect(ENV['DATABASE_URL'])
+DB.extension :pg_array
+
+ADDRESS_OBJECTS_TABLE_NAME = :address_objects
+ADDRESS_OBJECTS = DB[ADDRESS_OBJECTS_TABLE_NAME]
+
+def alter_table
+  puts 'Adding ancestry field...'
+
+  DB.alter_table(ADDRESS_OBJECTS_TABLE_NAME) do
+    add_column :ancestry, 'text'
+  end
+
+  DB.run 'CREATE INDEX idx_ancestry ON "address_objects" USING BTREE ("ancestry");'
+end
+
+def ancestry
+  puts 'Building ancestry...'
+
+  scope = ADDRESS_OBJECTS
+
+  bar = create_bar(scope.count)
+
+  scope.select(:id, :parentage).each do |row|
+    bar.increment
+
+    ADDRESS_OBJECTS.where(id: row[:id]).update(
+        ancestry: row[:parentage].reverse.join('/')
+    ) unless row[:parentage].empty?
+  end
+end
+
+alter_table
+ancestry

--- a/examples/generate_index.rb
+++ b/examples/generate_index.rb
@@ -21,14 +21,14 @@ def alter_table
 
   DB.alter_table(ADDRESS_OBJECTS_TABLE_NAME) do
     add_column :tokens, 'text[]'
-    add_column :ancestry, 'integer[]'
+    add_column :parentage, 'integer[]'
     add_column :forms, 'text[]'
   end
 
   DB.run 'CREATE INDEX idx_tokens on "address_objects" USING GIN ("tokens");'
 end
 
-def ancestry_for(id)
+def parentage_for(id)
   ADDRESS_OBJECTS
     .select(:id)
     .join(:address_object_hierarchies, ancestor_id: :id)
@@ -49,12 +49,12 @@ def tokenize
 
     tokens = Fias::Name::Synonyms.tokens(row[:name])
     forms = Fias::Name::Synonyms.forms(row[:name])
-    ancestry = ancestry_for(row[:id])
+    parentage = parentage_for(row[:id])
 
     ADDRESS_OBJECTS.where(id: row[:id]).update(
       tokens: Sequel.pg_array(tokens, :text),
       forms:  Sequel.pg_array(forms, :text),
-      ancestry: Sequel.pg_array(ancestry, :integer)
+      parentage: Sequel.pg_array(parentage, :integer)
     )
   end
 end

--- a/lib/fias.rb
+++ b/lib/fias.rb
@@ -21,6 +21,10 @@ module Fias
       @word ||=
         /(#{ANNIVESARIES}|#{indivisible_words.join('|')}|[#{LETTERS}\"\'\d\.\)\(\/\-]+)(\s|\,|$)/ui
     end
+
+    def setting(name)
+      config.settings.fetch(name.to_sym)
+    end
   end
 
   LETTERS        = /[а-яА-ЯёЁA-Za-z]/ui
@@ -204,4 +208,6 @@ Fias.configure do |config|
   synonyms.each do |synonym|
     config.add_synonym(*synonym)
   end
+
+  config.add_setting(:parentage_column, :parentage)
 end

--- a/lib/fias/config.rb
+++ b/lib/fias/config.rb
@@ -10,6 +10,7 @@ module Fias
       @replacements = {}
       @synonyms = []
       @synonyms_index = {}
+      @settings = {}
 
       yield(self)
 
@@ -18,6 +19,7 @@ module Fias
 
     attr_reader :index, :longs, :shorts, :aliases, :exceptions, :replacements
     attr_reader :proper_names, :synonyms, :synonyms_index
+    attr_reader :settings
 
     def add_name(long, short, aliases = [])
       @longs[Unicode.downcase(short)] = long
@@ -43,6 +45,10 @@ module Fias
     def add_synonym(*names)
       @synonyms << names
       populate_synonyms_index(names)
+    end
+
+    def add_setting(name, value)
+      @settings[name.to_sym] = value
     end
 
     private

--- a/lib/fias/query/estimate.rb
+++ b/lib/fias/query/estimate.rb
@@ -38,7 +38,7 @@ module Fias
       end
 
       def for_deepness
-        @chain.first[:ancestry].size * RATES[:deep]
+        parentage(@chain.first).size * RATES[:deep]
       end
 
       def for_name_proximity
@@ -53,6 +53,10 @@ module Fias
 
       def chain_by_key
         @chain_by_key ||= @chain.index_by { |item| item[:key] }
+      end
+
+      def parentage(chain)
+        chain[Fias.setting(:parentage_column).to_sym]
       end
 
       RATES = {

--- a/lib/fias/query/finder.rb
+++ b/lib/fias/query/finder.rb
@@ -52,10 +52,10 @@ module Fias
         parents = endpoints_parents
 
         chains = starting_endpoints.map do |endpoint|
-          overlaps = parents.keys & endpoint[:ancestry]
+          overlaps = parents.keys & parentage(endpoint)
 
           if parents.blank? || overlaps.present?
-            [endpoint] + endpoint[:ancestry].map { |id| parents[id] }.compact
+            [endpoint] + parentage(endpoint).map { |id| parents[id] }.compact
           end
         end
 
@@ -69,6 +69,18 @@ module Fias
           .flatten
           .reverse
           .index_by { |endpoint| endpoint[:id] }
+      end
+
+      def parentage(endpoint)
+        endpoint[Fias.setting(:parentage_column).to_sym].tap do |parentage|
+          warn(<<-DEPRECATE) unless parentage.is_a? Array
+            Now `ancestry` column was renamed to `parentage` for possibility of using Ancestry gem.
+            Please, add setting `parentage_column` in your app, if you want to continue use `ancestry` column.
+            ```
+              Fias.config.add_setting(:parentage_column, :ancestry)
+            ```
+          DEPRECATE
+        end
       end
     end
   end

--- a/lib/fias/version.rb
+++ b/lib/fias/version.rb
@@ -1,3 +1,3 @@
 module Fias
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end

--- a/spec/lib/import/dbf_spec.rb
+++ b/spec/lib/import/dbf_spec.rb
@@ -5,7 +5,7 @@ describe Fias::Import::Dbf do
 
   context '#initialize' do
     it 'fails without files' do
-      expect { described_class.new('foo') }.to raise_error
+      expect { described_class.new('foo') }.to raise_error(ArgumentError)
     end
 
     it 'returns correct file list' do

--- a/spec/support/db.rb
+++ b/spec/support/db.rb
@@ -2,7 +2,7 @@ DB = {}
 SHORTCUTS = {}
 
 YAML.load_file('spec/fixtures/addressing.yml').each.with_index do |item, index|
-  ancestry = item.inject([]) do |ancestry, element|
+  parentage = item.inject([]) do |parentage, element|
     name = element.last
     name, _, abbr, _ = Fias::Name::Extract.extract(name)
     tokens = Fias::Name::Synonyms.tokens(name)
@@ -11,18 +11,18 @@ YAML.load_file('spec/fixtures/addressing.yml').each.with_index do |item, index|
 
     DB[id] = {
       id: id,
-      parent_id: ancestry.last,
+      parent_id: parentage.last,
       name: name,
       abbr: abbr,
-      ancestry: ancestry.reverse,
+      parentage: parentage.reverse,
       tokens: tokens,
       forms: forms
     }
 
-    ancestry + [id]
+    parentage + [id]
   end
 
-  SHORTCUTS[index] = DB[ancestry.last]
+  SHORTCUTS[index] = DB[parentage.last]
 end
 
 def find_in_addressing_db(tokens)


### PR DESCRIPTION
К сожалению, для поиска используется колонка ancestry, что мешает подключить одноимённый гем без дополнительных телодвижений.

Предлагаю добавить настройку для установки названия колонки.

Плюс пример как сформировать данные для ancestry из данных closure tree.
