### PR TITLE
Add table prefix for fias:create_tables and fias:import

### DIFF
--- a/lib/fias/import/tables.rb
+++ b/lib/fias/import/tables.rb
@@ -1,10 +1,10 @@
 module Fias
   module Import
     class Tables
-      def initialize(db, files, prefix = DEFAULT_PREFIX)
+      def initialize(db, files, *prefix)
         @db = db
         @files = files
-        @prefix = prefix
+        @prefix = prefix.first || DEFAULT_PREFIX
       end
 
       attr_reader :files

--- a/lib/fias/import/tables.rb
+++ b/lib/fias/import/tables.rb
@@ -1,10 +1,10 @@
 module Fias
   module Import
     class Tables
-      def initialize(db, files, *prefix)
+      def initialize(db, files, prefix = DEFAULT_PREFIX)
         @db = db
         @files = files
-        @prefix = prefix.first || DEFAULT_PREFIX
+        @prefix = prefix
       end
 
       attr_reader :files

--- a/tasks/db.rake
+++ b/tasks/db.rake
@@ -43,7 +43,7 @@ namespace :fias do
     only = *ENV['TABLES'].to_s.split(',')
     files = Fias::Import::Dbf.new(fias_path).only(*only)
     prefix = ENV['PREFIX']
-    tables = Fias::Import::Tables.new(db, files, prefix)
+    tables = Fias::Import::Tables.new(db, files, *[prefix].compact)
 
     diff = only - files.keys.map(&:to_s)
     puts "WARNING: Missing DBF files for: #{diff.join(', ')}" if diff.any?

--- a/tasks/db.rake
+++ b/tasks/db.rake
@@ -42,7 +42,8 @@ namespace :fias do
     fias_path = ENV['FIAS_PATH'] || 'tmp/fias'
     only = *ENV['TABLES'].to_s.split(',')
     files = Fias::Import::Dbf.new(fias_path).only(*only)
-    tables = Fias::Import::Tables.new(db, files)
+    prefix = ENV['PREFIX']
+    tables = Fias::Import::Tables.new(db, files, prefix)
 
     diff = only - files.keys.map(&:to_s)
     puts "WARNING: Missing DBF files for: #{diff.join(', ')}" if diff.any?


### PR DESCRIPTION
Добавление своих префиксов работает не всегда, а каким-то случайным образом. К примеру,  
```
bundle exec rake fias:create_tables fias:import DATABASE_URL=postgres://usr:pwd@localhost/fias FIAS_PATH="/tmp/fias/updates/" PREFIX="test"
```
 не изменяет стандартного префикса таблиц.

По всей видимости соответствующая переменная не обрабатывалась как должна была.