### PR TITLE
Update dbf.rb

### DIFF
--- a/lib/fias/import/dbf.rb
+++ b/lib/fias/import/dbf.rb
@@ -56,6 +56,8 @@ module Fias
 
       HOUSE_TABLES = n_tables('house')
       NORDOC_TABLES = n_tables('nordoc')
+      ROOM_TABLES = n_tables('room')
+      STEAD_TABLES = n_tables('stead')
 
       TABLES = {
         address_object_types: 'SOCRBASE.DBF',
@@ -69,11 +71,16 @@ module Fias
         address_objects: 'ADDROBJ.DBF',
         house_intervals: 'HOUSEINT.DBF',
         landmarks: 'LANDMARK.DBF',
-        house_state_statuses: 'HSTSTAT.DBF'
+        house_state_statuses: 'HSTSTAT.DBF',
+        norm_doc_types: 'NDOCTYPE.DBF'
       }.merge(
         HOUSE_TABLES
       ).merge(
         NORDOC_TABLES
+      ).merge(
+         ROOM_TABLES
+      ).merge(
+         STEAD_TABLES
       )
 
       DEFAULT_ENCODING = Encoding::CP866


### PR DESCRIPTION
Расширяет число создаваемых таблиц при импорте вследствие включения в БД ФИАС данных по помещениям(ROOMXX.DBF) и по участкам земли(STEADXX.DBF) - по таблице для каждого региона(в сумме свыше 145 таблиц)
Включает в число импортируемых таблиц обработку файла NDOCTYPE.DBF, содержащего справочную информацию по типам документов из файлов NORDOCXX.DBF. В сведениях о составе информации Федеральной информационной адресной системы(http://goo.gl/zkDX6X) этот файл не описан, но по факту он присутствует во всех полных архивах БД ФИАС.