### PR TITLE
bugfix: parent records were not actual

### DIFF
--- a/lib/fias/import/restore_parent_id.rb
+++ b/lib/fias/import/restore_parent_id.rb
@@ -5,6 +5,7 @@ module Fias
         @scope = scope
         @key = options.fetch(:key, :aoguid)
         @parent_key = options.fetch(:parent_key, :parentguid)
+        @nextid_key = options.fetch(:nextid_key, :nextid)
         @id = options.fetch(:id, :id)
         @parent_id = options.fetch(:parent_id, :parent_id)
       end
@@ -18,11 +19,13 @@ module Fias
       private
 
       def records
-        @records ||= @scope.select_map([@id, @key, @parent_key])
+        @records ||= @scope.select_map([@id, @key, @parent_key, @nextid_key])
       end
 
       def records_by_key
-        @records_by_key ||= records.index_by { |r| r[1] }
+        @records_by_key ||= {}.tap do |rbk|
+          records.each { |r| rbk[r[1]] = r if r[3].blank? }
+        end
       end
 
       def id_parent_id_tuples


### PR DESCRIPTION
parent record must be "live", live records at least have no "nextid"
column. 

For example we have region "Читинская область" for aoguid#a4b18a69-c5df-4022-ba9b-a29f99acfa42, but actually it is "Забайкальский край"