### PR TITLE
Makes the gem fully workable to deploy with actual structure of FIAS database

### DIFF
--- a/lib/fias/import/dbf.rb
+++ b/lib/fias/import/dbf.rb
@@ -17,8 +17,11 @@ module Fias
 
         names = names.map do |name|
           name = name.to_sym
+          name == :addresses ? ADDRESS_TABLES.keys : name
           name == :houses ? HOUSE_TABLES.keys : name
           name == :nordocs ? NORDOC_TABLES.keys : name
+          name == :rooms ? ROOM_TABLES.keys : name
+          name == :steads ? STEAD_TABLES.keys : name
         end
 
         names.flatten!
@@ -54,26 +57,35 @@ module Fias
         Hash[*tables]
       end
 
+      ADDRESS_TABLES = n_tables('addrob')
       HOUSE_TABLES = n_tables('house')
       NORDOC_TABLES = n_tables('nordoc')
+      STEAD_TABLES = n_tables('stead')
+      ROOM_TABLES = n_tables('room')
 
       TABLES = {
-        address_object_types: 'SOCRBASE.DBF',
-        current_statuses: 'CURENTST.DBF',
-        actual_statuses: 'ACTSTAT.DBF',
-        operation_statuses: 'OPERSTAT.DBF',
-        center_statuses: 'CENTERST.DBF',
-        interval_statuses: 'INTVSTAT.DBF',
-        estate_statues: 'ESTSTAT.DBF',
-        structure_statuses: 'STRSTAT.DBF',
-        address_objects: 'ADDROBJ.DBF',
-        house_intervals: 'HOUSEINT.DBF',
-        landmarks: 'LANDMARK.DBF',
-        house_state_statuses: 'HSTSTAT.DBF'
+         address_object_types: 'SOCRBASE.DBF',
+         current_statuses: 'CURENTST.DBF',
+         actual_statuses: 'ACTSTAT.DBF',
+         operation_statuses: 'OPERSTAT.DBF',
+         center_statuses: 'CENTERST.DBF',
+         interval_statuses: 'INTVSTAT.DBF',
+         estate_statues: 'ESTSTAT.DBF',
+         structure_statuses: 'STRSTAT.DBF',
+         house_intervals: 'HOUSEINT.DBF',
+         landmarks: 'LANDMARK.DBF',
+         nordoc_types: 'NDOCTYPE.DBF',
+         house_state_statuses: 'HSTSTAT.DBF'
       }.merge(
-        HOUSE_TABLES
+         ADDRESS_TABLES
       ).merge(
-        NORDOC_TABLES
+         HOUSE_TABLES
+      ).merge(
+         NORDOC_TABLES
+      ).merge(
+         STEAD_TABLES
+      ).merge(
+         ROOM_TABLES
       )
 
       DEFAULT_ENCODING = Encoding::CP866

--- a/lib/fias/import/tables.rb
+++ b/lib/fias/import/tables.rb
@@ -43,7 +43,7 @@ module Fias
       end
 
       def column_for(name, column)
-        alter = UUID[name]
+        alter = UUID[name.to_s[/^\D+/].to_sym]
         column_name = column.name.downcase
 
         parse_c_def(column.schema_definition).tap do |c_def|
@@ -60,12 +60,16 @@ module Fias
       end
 
       def uuid_column_types(name)
-        uuid = UUID[name] || []
+        uuid = UUID[name.to_s[/^\D+/].to_sym] || []
         Hash[*uuid.zip([:uuid] * uuid.size).flatten]
       end
 
       UUID = {
-        address_objects: %w(aoguid aoid previd nextid parentguid)
+         addrob: %w(aoguid aoid previd nextid parentguid normdoc),
+         house: %w(aoguid houseguid houseid normdoc),
+         stead: %w(steadguid parentguid steadid nextid previd normdoc),
+         room: %w(roomid roomguid houseguid nextid previd normdoc),
+         nordoc: %w(normdocid)
       }
 
       DEFAULT_PREFIX = 'fias'

--- a/tasks/db.rake
+++ b/tasks/db.rake
@@ -20,6 +20,7 @@ namespace :fias do
           total: table.dbf.record_count,
           format: '%a |%B| [%E] (%c/%C) %p%%'
         )
+        next if table.dbf.record_count.eql? 0
 
         table.encode { bar.increment }
         table.copy


### PR DESCRIPTION
1. Correlates tables and DBF-files from the FIAS database archive
2. Helps to set uuid-type to the right columns in the database
3. Prevents to import from empty DBF-file